### PR TITLE
Log likelihood summation typo

### DIFF
--- a/my_notes/notes.tex
+++ b/my_notes/notes.tex
@@ -601,7 +601,7 @@
 				\end{align*}
 			\item Log likelihood is,
 				\begin{align*}
-					l(\mu, \sigma) = \ln \sum_{i=1}^{n} P(x_{i})
+					l(\mu, \sigma) = \sum_{i=1}^{n} \ln P(x_{i})
 				\end{align*}
 			\item Want to set $\triangledown_{\mu} l = 0$, and  $\frac{\partial l}{\partial \sigma} = 0$.
 			\item Natural log of Gaussian distribution,


### PR DESCRIPTION
The summation should be outside of the logs (otherwise it should be a product symbol).